### PR TITLE
Add support for karaf 4.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 *.i??
 .classpath
 .project
+.settings
+*.jar

--- a/plugins/org.apache.karaf.eik.core/plugin.xml
+++ b/plugins/org.apache.karaf.eik.core/plugin.xml
@@ -18,11 +18,6 @@
       <model
             class="org.apache.karaf.eik.core.internal.GenericKarafPlatformModelFactory">
          <triggerBundle
-               symbolicName="org.apache.karaf.main"></triggerBundle>
-         <triggerBundle
-               symbolicName="org.apache.felix.karaf.jaas.boot">
-         </triggerBundle>
-         <triggerBundle
                symbolicName="org.apache.karaf.main">
          </triggerBundle>
          <triggerBundle

--- a/plugins/org.apache.karaf.eik.core/src/main/java/org/apache/karaf/eik/core/internal/GenericKarafPlatformValidator.java
+++ b/plugins/org.apache.karaf.eik.core/src/main/java/org/apache/karaf/eik/core/internal/GenericKarafPlatformValidator.java
@@ -18,6 +18,10 @@
  */
 package org.apache.karaf.eik.core.internal;
 
+import java.io.File;
+import java.io.FilenameFilter;
+import java.nio.file.Paths;
+
 import org.apache.karaf.eik.core.KarafPlatformValidator;
 
 import org.eclipse.core.runtime.IPath;
@@ -26,13 +30,23 @@ public class GenericKarafPlatformValidator implements KarafPlatformValidator {
 
     public boolean isValid(IPath rootPath) {
         final IPath karafJar = rootPath.append("/lib/karaf.jar");
+        final IPath bootDir = rootPath.append("/lib/boot");
 
         final IPath systemDir = rootPath.append("/system");
         final IPath confDir = rootPath.append("/etc");
 
         // First level is the Karaf JARs in the lib directory
-        if (karafJar.toFile().exists()) {
-            return true;
+        if (karafJar.toFile().exists()) { // karaf 3.X
+        	return true; 
+        }
+        if (bootDir.toFile().isDirectory()) { // karaf 4.X
+        	String[] karafLibs = bootDir.toFile().list(new FilenameFilter() {
+				@Override
+				public boolean accept(File dir, String name) {
+					return name.startsWith("org.apache.karaf.main");
+				}
+			});
+            return karafLibs.length > 0; 
         }
 
         /*
@@ -40,7 +54,7 @@ public class GenericKarafPlatformValidator implements KarafPlatformValidator {
          * configuration files.
          */
         if(systemDir.toFile().isDirectory() && confDir.toFile().isDirectory()) {
-            final IPath karafFeatures = confDir.append("/org.apache.felix.karaf.features.cfg");
+            final IPath karafFeatures = confDir.append("/org.apache.karaf.features.cfg");
 
             if(karafFeatures.toFile().exists()) {
                 return true;

--- a/plugins/org.apache.karaf.eik.core/src/main/java/org/apache/karaf/eik/core/model/GenericKarafPlatformModel.java
+++ b/plugins/org.apache.karaf.eik.core/src/main/java/org/apache/karaf/eik/core/model/GenericKarafPlatformModel.java
@@ -99,6 +99,7 @@ public class GenericKarafPlatformModel extends AbstractKarafPlatformModel implem
     public List<String> getBootClasspath() {
         final List<File> jarFiles = new ArrayList<File>();
         KarafCorePluginUtils.getJarFileList(rootPlatformPath.append("lib").toFile(), jarFiles, 0);
+        KarafCorePluginUtils.getJarFileList(rootPlatformPath.append("lib").append("boot").toFile(), jarFiles, 0);
 
         final List<String> bootClasspath = new ArrayList<String>();
         for(final File f : jarFiles) {

--- a/plugins/org.apache.karaf.eik.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.apache.karaf.eik.ui/META-INF/MANIFEST.MF
@@ -21,6 +21,7 @@ Require-Bundle: org.eclipse.ant.core;bundle-version="3.2.201",
  org.apache.karaf.eik.core;bundle-version="[3.0.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.apache.karaf.eik.ui,
+ org.apache.karaf.eik.ui.project,
  org.apache.karaf.eik.ui.wizards,
  org.apache.karaf.eik.ui.workbench
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.apache.karaf.eik.ui/src/main/java/org/apache/karaf/eik/ui/features/FeaturesResolverJob.java
+++ b/plugins/org.apache.karaf.eik.ui/src/main/java/org/apache/karaf/eik/ui/features/FeaturesResolverJob.java
@@ -113,9 +113,12 @@ public final class FeaturesResolverJob extends Job {
                     final Properties runtimeProperties = karafProject.getRuntimeProperties();
 
                     PropertyUtils.interpolateVariables(mvnConfiguration, runtimeProperties);
-
-                    final String defaultRepos = (String) mvnConfiguration.get("org.ops4j.pax.url.mvn.defaultRepositories");
-                    final String repos = (String) mvnConfiguration.get("org.ops4j.pax.url.mvn.repositories");
+                    
+                    // Remove whitespaces in lists as these lead to errors in OPS4j
+                    final String defaultRepos = ((String) mvnConfiguration.get("org.ops4j.pax.url.mvn.defaultRepositories")); //.replaceAll("\\s+", "");
+                    mvnConfiguration.setProperty("org.ops4j.pax.url.mvn.defaultRepositories", defaultRepos);
+                    final String repos = ((String) mvnConfiguration.get("org.ops4j.pax.url.mvn.repositories")); //.replaceAll("\\s+", "");
+                    mvnConfiguration.setProperty("org.ops4j.pax.url.mvn.repositories", repos);
 
                     // In karaf-3.0.0, default repo may be null.
                     // First check if it's null an if not then add it to repo list

--- a/plugins/org.apache.karaf.eik.ui/src/main/java/org/apache/karaf/eik/ui/internal/KarafLaunchUtils.java
+++ b/plugins/org.apache.karaf.eik.ui/src/main/java/org/apache/karaf/eik/ui/internal/KarafLaunchUtils.java
@@ -77,6 +77,7 @@ public final class KarafLaunchUtils {
         // Add the lib directory for completeness, if the developer is pulling a
         // target platform they better know what the are doing
         directories.add(karafPlatformModel.getRootDirectory().append("lib").toFile()); // $NON-NLS-1$
+        directories.add(karafPlatformModel.getRootDirectory().append("lib").append("boot").toFile()); // $NON-NLS-1$
 
         return directories;
     }


### PR DESCRIPTION
We are using a somewhat special way of the eik-plugin, but this works for us with karaf 4.0.x. Maybe it would make sense to use a 4.0.x branch for it, as I am not 100% sure about backwards compatibility with karaf 3.x